### PR TITLE
fix: add env_file to docker-compose for environment variable support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: claude-code-ui
+    env_file:
+      - .env
     ports:
       - "3001:3001"
     environment:


### PR DESCRIPTION
## 问题描述

修复 #2 - Docker 容器无法读取宿主机 .env 文件中的环境变量

## 问题重现

在修复前：
1. 用户在 `.env` 文件中配置 `ANTHROPIC_AUTH_TOKEN` 和 `ANTHROPIC_BASE_URL`
2. 启动容器后，环境变量不存在
3. Claude CLI 报错：`Invalid API key`

验证方式：
```bash
docker exec claude-code-ui env | grep ANTHROPIC
# 无输出
```

## 解决方案

在 `docker-compose.yml` 中添加 `env_file` 指令：

```yaml
services:
  claude-code-ui:
    env_file:
      - .env
```

## 修复验证

修复后：
```bash
docker exec claude-code-ui env | grep ANTHROPIC
ANTHROPIC_AUTH_TOKEN=cr_xxx...
ANTHROPIC_BASE_URL=https://relay.deepractice.ai/api
```

## 改动内容

- 在 `docker-compose.yml` 的 `claude-code-ui` 服务中添加 `env_file: [.env]`
- 确保 `.env` 文件中的所有环境变量都能传入容器

## 测试

- [x] 重现问题（环境变量不存在）
- [x] 应用修复（添加 env_file）
- [x] 验证修复（环境变量成功传入）

Closes #2