### PR TITLE
feat: implement session error recovery mechanism

### DIFF
--- a/.changeset/session-error-recovery.md
+++ b/.changeset/session-error-recovery.md
@@ -1,0 +1,33 @@
+---
+"@deepractice-ai/agent": minor
+"@deepractice-ai/agent-sdk": minor
+---
+
+Implement session error recovery mechanism to handle recoverable errors
+
+This change distinguishes between recoverable and fatal errors, allowing sessions to continue after temporary failures like insufficient credits or rate limits.
+
+**Changes:**
+
+SDK (`@deepractice-ai/agent-sdk`):
+- Added `isRecoverableError()` utility function to detect recoverable errors (402, 429, timeouts, 503)
+- Modified `ClaudeSession.send()` to return to `idle` state for recoverable errors instead of `error` state
+- Added `_lastError` tracking and `getLastError()` public method
+- Updated `Session` interface to include `getLastError()` method
+
+Server (`apps/agent/server`):
+- Added state guard in `chat.js` to prevent sending messages to completed sessions
+- Enhanced error responses with `recoverable` and `state` flags
+
+Frontend (`apps/agent/web`):
+- Updated event types to include `recoverable` and `state` fields for error events
+- Enhanced `WebSocketAdapter` to parse and forward error recovery information
+- Improved `messageStore` to display context-aware error messages:
+  - Recoverable: "⚠️ Error message ✅ Session still active, you can continue"
+  - Fatal: "❌ Error message ⛔ Session failed, please create new session"
+
+**User Impact:**
+
+Before: Any API error (including temporary ones like insufficient credits) would permanently terminate the session, forcing users to create new sessions and lose conversation context.
+
+After: Recoverable errors (insufficient credits, rate limits, timeouts) allow the session to remain active. Users can resolve the issue (e.g., add credits) and continue the conversation without losing context.

--- a/apps/agent/web/src/core/events.ts
+++ b/apps/agent/web/src/core/events.ts
@@ -29,14 +29,14 @@ export type MessageEvent =
   | { type: "message.complete"; sessionId: string }
   | { type: "message.tool"; sessionId: string; toolName: string; toolInput: string; toolId: string }
   | { type: "message.toolResult"; sessionId: string; toolId: string; result: any }
-  | { type: "message.error"; sessionId: string; error: Error };
+  | { type: "message.error"; sessionId: string; error: Error; recoverable?: boolean; state?: string };
 
 // Agent Events
 export type AgentEvent =
   | { type: "agent.thinking"; sessionId: string }
   | { type: "agent.processing"; sessionId: string; status?: string; tokens?: number }
   | { type: "agent.complete"; sessionId: string }
-  | { type: "agent.error"; sessionId: string; error: Error }
+  | { type: "agent.error"; sessionId: string; error: Error; recoverable?: boolean; state?: string }
   | { type: "agent.abort"; sessionId: string; timestamp: number };
 
 // UI Events

--- a/packages/agent-sdk/src/types/session.ts
+++ b/packages/agent-sdk/src/types/session.ts
@@ -61,6 +61,7 @@ export interface Session {
   getMessages(limit?: number, offset?: number): AnyMessage[];
   getTokenUsage(): TokenUsage;
   getMetadata(): SessionMetadata;
+  getLastError(): Error | null;
   summary(): string;
 
   // Utilities


### PR DESCRIPTION
## Summary

Implements session error recovery to distinguish between **recoverable** and **fatal** errors, allowing sessions to continue after temporary failures like insufficient credits or rate limits.

## Problem

Currently, **any** API error (including temporary ones) permanently terminates the session with `error` state, forcing users to:
- ❌ Create new sessions
- ❌ Lose conversation context
- ❌ Re-provide all previous information

This is particularly problematic for:
- 💳 **402 Payment Required** - User runs out of credits mid-conversation
- 🚦 **429 Rate Limit** - Temporary API throttling
- ⏱️ **Network timeouts** - Transient connectivity issues

## Solution

### Three-Layer Protection

#### 1️⃣ SDK Layer - Error Classification
- New `isRecoverableError()` utility detects recoverable errors (402, 429, timeouts, 503)
- Recoverable errors: Session returns to `idle` state (can continue)
- Fatal errors: Session enters `error` state (terminated)
- Track last error via `getLastError()` method

#### 2️⃣ Server Layer - State Guard
- Validate session state before calling `session.send()`
- Reject operations on completed/error sessions early
- Return enhanced error responses with `recoverable` and `state` flags

#### 3️⃣ Frontend Layer - User Feedback
- Context-aware error messages:
  - ⚠️ Recoverable: "Session still active, you can continue"
  - ❌ Fatal: "Session failed, please create new session"
- Parse recovery information from WebSocket events

## Changes

### SDK (`@deepractice-ai/agent-sdk`)
- ✅ Add `isRecoverableError()` utility function
- ✅ Modify `ClaudeSession.send()` error handling
- ✅ Add `_lastError` field and `getLastError()` method
- ✅ Update `Session` interface

### Server (`apps/agent/server`)
- ✅ Add session state guard in `chat.js`
- ✅ Enhance error responses with recovery metadata

### Frontend (`apps/agent/web`)
- ✅ Update event types for error recovery
- ✅ Enhance `WebSocketAdapter` to parse recovery flags
- ✅ Improve `messageStore` error messaging

## User Impact

### Before
```
User: "Analyze this code"
Agent: [402 Insufficient Credits]
System: ❌ Session terminated (state: error)
User: Must create new session → Lost all context
```

### After
```
User: "Analyze this code"
Agent: [402 Insufficient Credits]
System: ⚠️ Error occurred
        ✅ Session still active, you can continue
User: [Adds credits]
User: "Continue analysis"
Agent: ✅ Responds successfully with full context preserved
```

## Test Plan

### Manual Testing
- [ ] Test recoverable error (402): Session remains in `idle` state
- [ ] Test recoverable error (429): Session can continue after delay
- [ ] Test fatal error (401): Session enters `error` state
- [ ] Test state guard: Cannot send to terminated sessions
- [ ] Verify error messages display correctly
- [ ] Verify context preservation after recoverable errors

### Regression Testing
- [ ] Normal session flow unaffected
- [ ] Session abort still works
- [ ] Multiple sessions independent
- [ ] Error logging intact

## Screenshots

_Add screenshots showing error messages for recoverable vs fatal errors_

## Notes

- Error detection is conservative: Unknown errors default to **fatal**
- Recoverable error list can be extended based on production data
- Session state guard prevents wasted API calls
- No breaking changes to existing API contracts

## Checklist

- [x] Code follows project conventions
- [x] Added changeset file
- [x] Error handling improved
- [x] User experience enhanced
- [ ] Manual testing completed
- [ ] Ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)