### PR TITLE
feat(ui): add interrupt functionality with ESC key and AssistantToolbar

### DIFF
--- a/.changeset/interrupt-enhancement.md
+++ b/.changeset/interrupt-enhancement.md
@@ -1,0 +1,11 @@
+---
+"@agentxjs/ui": minor
+---
+
+Add interrupt functionality with ESC key support and AssistantToolbar
+
+- Add AssistantToolbar component with action buttons (copy, regenerate, like, dislike)
+- Show "esc to stop" hint during streaming/thinking states
+- Show action buttons when conversation is completed
+- Add ESC key listener in Chat component to interrupt ongoing conversations
+- Pass onStop callback to AssistantEntry for toolbar click handling

--- a/packages/ui/src/components/container/Chat.tsx
+++ b/packages/ui/src/components/container/Chat.tsx
@@ -70,7 +70,8 @@ export interface ChatProps {
 function renderConversation(
   conversation: ConversationData,
   streamingText: string,
-  currentTextBlockId: string | null
+  currentTextBlockId: string | null,
+  onStop?: () => void
 ): React.ReactNode {
   switch (conversation.type) {
     case "user":
@@ -83,6 +84,7 @@ function renderConversation(
           entry={conversation}
           streamingText={streamingText}
           currentTextBlockId={currentTextBlockId}
+          onStop={onStop}
         />
       );
 
@@ -119,6 +121,19 @@ export function Chat({
     status === "responding" ||
     status === "planning_tool" ||
     status === "awaiting_tool_result";
+
+  // ESC key to interrupt
+  React.useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isLoading) {
+        e.preventDefault();
+        interrupt();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isLoading, interrupt]);
 
   // Toolbar items
   const toolbarItems: ToolBarItem[] = React.useMemo(
@@ -170,7 +185,9 @@ export function Chat({
       {/* Message area */}
       <div style={{ height: messageHeight }} className="min-h-0">
         <MessagePane>
-          {conversations.map((conv) => renderConversation(conv, streamingText, currentTextBlockId))}
+          {conversations.map((conv) =>
+            renderConversation(conv, streamingText, currentTextBlockId, interrupt)
+          )}
         </MessagePane>
       </div>
 

--- a/packages/ui/src/components/entry/AssistantEntry.stories.tsx
+++ b/packages/ui/src/components/entry/AssistantEntry.stories.tsx
@@ -277,3 +277,118 @@ export const ConversationFlow: Story = {
     </div>
   ),
 };
+
+// Stories with Stop button
+const queuedEntry: AssistantConversationData = {
+  type: "assistant",
+  id: "msg_queued",
+  messageIds: [],
+  timestamp: Date.now(),
+  status: "queued",
+  blocks: [],
+};
+
+const thinkingEntry: AssistantConversationData = {
+  type: "assistant",
+  id: "msg_thinking",
+  messageIds: [],
+  timestamp: Date.now(),
+  status: "thinking",
+  blocks: [],
+};
+
+const processingEntry: AssistantConversationData = {
+  type: "assistant",
+  id: "msg_processing",
+  messageIds: [],
+  timestamp: Date.now(),
+  status: "processing",
+  blocks: [],
+};
+
+// Toolbar handlers
+const toolbarHandlers = {
+  onStop: () => console.log("Stop clicked"),
+  onCopy: () => console.log("Copy clicked"),
+  onRegenerate: () => console.log("Regenerate clicked"),
+  onLike: () => console.log("Like clicked"),
+  onDislike: () => console.log("Dislike clicked"),
+};
+
+export const WithToolbarStreaming: Story = {
+  args: {
+    entry: streamingEntry,
+    streamingText: "I'm generating a response for you. This might take a moment...",
+    currentTextBlockId: "text_001",
+    ...toolbarHandlers,
+  },
+};
+
+export const WithToolbarCompleted: Story = {
+  args: {
+    entry: completedEntry,
+    ...toolbarHandlers,
+  },
+};
+
+export const QueuedWithToolbar: Story = {
+  args: {
+    entry: queuedEntry,
+    ...toolbarHandlers,
+  },
+};
+
+export const ThinkingWithToolbar: Story = {
+  args: {
+    entry: thinkingEntry,
+    ...toolbarHandlers,
+  },
+};
+
+export const ToolbarStates: Story = {
+  render: () => (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-sm font-medium text-muted-foreground mb-2">
+          Queued (shows: esc to stop)
+        </h3>
+        <AssistantEntry entry={queuedEntry} {...toolbarHandlers} />
+      </div>
+      <div>
+        <h3 className="text-sm font-medium text-muted-foreground mb-2">
+          Processing (shows: esc to stop)
+        </h3>
+        <AssistantEntry entry={processingEntry} {...toolbarHandlers} />
+      </div>
+      <div>
+        <h3 className="text-sm font-medium text-muted-foreground mb-2">
+          Thinking (shows: esc to stop)
+        </h3>
+        <AssistantEntry entry={thinkingEntry} {...toolbarHandlers} />
+      </div>
+      <div>
+        <h3 className="text-sm font-medium text-muted-foreground mb-2">
+          Streaming (shows: esc to stop)
+        </h3>
+        <AssistantEntry
+          entry={streamingEntry}
+          streamingText="Let me help you with that question..."
+          currentTextBlockId="text_001"
+          {...toolbarHandlers}
+        />
+      </div>
+      <div>
+        <h3 className="text-sm font-medium text-muted-foreground mb-2">
+          Completed (shows: copy, regenerate, like, dislike)
+        </h3>
+        <AssistantEntry entry={completedEntry} {...toolbarHandlers} />
+      </div>
+      <div>
+        <h3 className="text-sm font-medium text-muted-foreground mb-2">
+          Completed with long content
+        </h3>
+        <AssistantEntry entry={longContentEntry} {...toolbarHandlers} />
+      </div>
+    </div>
+  ),
+};

--- a/packages/ui/src/components/entry/AssistantEntry.tsx
+++ b/packages/ui/src/components/entry/AssistantEntry.tsx
@@ -44,6 +44,7 @@ import * as React from "react";
 import { MessageAvatar } from "~/components/message/MessageAvatar";
 import { TextBlock } from "./blocks/TextBlock";
 import { ToolBlock } from "./blocks/ToolBlock";
+import { AssistantToolbar } from "./AssistantToolbar";
 import { cn } from "~/utils/utils";
 import type { AssistantConversationData, BlockData } from "./types";
 
@@ -60,6 +61,26 @@ export interface AssistantEntryProps {
    * Current streaming text block id
    */
   currentTextBlockId?: string | null;
+  /**
+   * Callback when stop is triggered
+   */
+  onStop?: () => void;
+  /**
+   * Callback when copy button is clicked
+   */
+  onCopy?: () => void;
+  /**
+   * Callback when regenerate button is clicked
+   */
+  onRegenerate?: () => void;
+  /**
+   * Callback when like button is clicked
+   */
+  onLike?: () => void;
+  /**
+   * Callback when dislike button is clicked
+   */
+  onDislike?: () => void;
   /**
    * Additional class name
    */
@@ -103,6 +124,11 @@ export const AssistantEntry: React.FC<AssistantEntryProps> = ({
   entry,
   streamingText = "",
   currentTextBlockId,
+  onStop,
+  onCopy,
+  onRegenerate,
+  onLike,
+  onDislike,
   className,
 }) => {
   const [dots, setDots] = React.useState("");
@@ -153,6 +179,9 @@ export const AssistantEntry: React.FC<AssistantEntryProps> = ({
     (entry.status === "queued" || entry.status === "processing" || entry.status === "thinking") &&
     !hasBlocks;
 
+  // Show toolbar if any callback is provided
+  const showToolbar = onStop || onCopy || onRegenerate || onLike || onDislike;
+
   return (
     <div className={cn("flex gap-3 py-2", className)}>
       <MessageAvatar role="assistant" />
@@ -162,6 +191,18 @@ export const AssistantEntry: React.FC<AssistantEntryProps> = ({
 
         {/* Render blocks in order */}
         {entry.blocks.map((block) => renderBlock(block, streamingText, currentTextBlockId))}
+
+        {/* Toolbar */}
+        {showToolbar && (
+          <AssistantToolbar
+            status={entry.status}
+            onStop={onStop}
+            onCopy={onCopy}
+            onRegenerate={onRegenerate}
+            onLike={onLike}
+            onDislike={onDislike}
+          />
+        )}
       </div>
     </div>
   );

--- a/packages/ui/src/components/entry/AssistantToolbar.tsx
+++ b/packages/ui/src/components/entry/AssistantToolbar.tsx
@@ -1,0 +1,150 @@
+/**
+ * AssistantToolbar - Toolbar for assistant message actions
+ *
+ * Displays action buttons below assistant messages:
+ * - Copy, regenerate, like, dislike for completed messages
+ * - "esc to stop" hint for streaming messages
+ *
+ * @example
+ * ```tsx
+ * <AssistantToolbar
+ *   status="completed"
+ *   onCopy={() => handleCopy()}
+ *   onRegenerate={() => handleRegenerate()}
+ * />
+ * ```
+ */
+
+import * as React from "react";
+import { Copy, RefreshCw, ThumbsUp, ThumbsDown } from "lucide-react";
+import { cn } from "~/utils/utils";
+import type { AssistantConversationStatus } from "./types";
+
+export interface AssistantToolbarProps {
+  /**
+   * Current status of the conversation
+   */
+  status: AssistantConversationStatus;
+  /**
+   * Callback when copy button is clicked
+   */
+  onCopy?: () => void;
+  /**
+   * Callback when regenerate button is clicked
+   */
+  onRegenerate?: () => void;
+  /**
+   * Callback when like button is clicked
+   */
+  onLike?: () => void;
+  /**
+   * Callback when dislike button is clicked
+   */
+  onDislike?: () => void;
+  /**
+   * Callback when stop is triggered (click or ESC)
+   */
+  onStop?: () => void;
+  /**
+   * Additional class name
+   */
+  className?: string;
+}
+
+/**
+ * Toolbar button component
+ */
+const ToolbarButton: React.FC<{
+  icon: React.ReactNode;
+  label: string;
+  onClick?: () => void;
+}> = ({ icon, label, onClick }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={cn(
+      "p-1.5 rounded-md",
+      "text-muted-foreground/60 hover:text-muted-foreground",
+      "hover:bg-muted/50",
+      "transition-colors duration-150"
+    )}
+    title={label}
+  >
+    {icon}
+  </button>
+);
+
+/**
+ * AssistantToolbar Component
+ */
+export const AssistantToolbar: React.FC<AssistantToolbarProps> = ({
+  status,
+  onCopy,
+  onRegenerate,
+  onLike,
+  onDislike,
+  onStop,
+  className,
+}) => {
+  const isStreaming =
+    status === "queued" ||
+    status === "processing" ||
+    status === "thinking" ||
+    status === "streaming";
+
+  const isCompleted = status === "completed";
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1 pt-1",
+        // Fade in animation
+        "animate-in fade-in duration-200",
+        className
+      )}
+    >
+      {/* Streaming: show stop hint */}
+      {isStreaming && onStop && (
+        <span
+          className="text-xs text-muted-foreground/40 cursor-pointer hover:text-muted-foreground/60 transition-colors select-none"
+          onClick={onStop}
+        >
+          esc to stop
+        </span>
+      )}
+
+      {/* Completed: show action buttons */}
+      {isCompleted && (
+        <>
+          {onCopy && (
+            <ToolbarButton icon={<Copy className="w-3.5 h-3.5" />} label="Copy" onClick={onCopy} />
+          )}
+          {onRegenerate && (
+            <ToolbarButton
+              icon={<RefreshCw className="w-3.5 h-3.5" />}
+              label="Regenerate"
+              onClick={onRegenerate}
+            />
+          )}
+          <div className="w-px h-4 bg-border mx-1" />
+          {onLike && (
+            <ToolbarButton
+              icon={<ThumbsUp className="w-3.5 h-3.5" />}
+              label="Like"
+              onClick={onLike}
+            />
+          )}
+          {onDislike && (
+            <ToolbarButton
+              icon={<ThumbsDown className="w-3.5 h-3.5" />}
+              label="Dislike"
+              onClick={onDislike}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default AssistantToolbar;


### PR DESCRIPTION
## Summary
- Add `AssistantToolbar` component with action buttons (copy, regenerate, like, dislike)
- Show "esc to stop" hint during streaming/thinking/queued states
- Show action buttons when conversation is completed
- Add ESC key listener in `Chat` component to interrupt ongoing conversations
- Pass `onStop` callback to `AssistantEntry` for toolbar click handling

## Changes
- `packages/ui/src/components/entry/AssistantToolbar.tsx` - New toolbar component
- `packages/ui/src/components/entry/AssistantEntry.tsx` - Integrate toolbar, add new props
- `packages/ui/src/components/container/Chat.tsx` - Add ESC key listener
- `packages/ui/src/components/entry/AssistantEntry.stories.tsx` - Add toolbar stories

## Test plan
- [ ] Verify ESC key interrupts ongoing conversations
- [ ] Verify "esc to stop" text appears during streaming
- [ ] Verify action buttons appear after conversation completes
- [ ] Check Storybook for visual verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)