### PR TITLE
fix(portagent): remove hardcoded wsUrl to fix Docker WebSocket connection

### DIFF
--- a/.changeset/fix-docker-websocket.md
+++ b/.changeset/fix-docker-websocket.md
@@ -1,0 +1,9 @@
+---
+"@agentxjs/portagent": patch
+---
+
+fix(portagent): remove hardcoded wsUrl to fix Docker WebSocket connection
+
+Bun compiler inlined `process.env.NODE_ENV !== "production"` as `true` during build, causing wsUrl to always return `ws://localhost:5200/ws` even in production Docker environments. This broke WebSocket connections when accessing from external hosts.
+
+Solution: Remove wsUrl from server response entirely. Frontend now always uses `window.location.host` to construct WebSocket URL. This works for both development (Vite proxy forwards /ws) and production (same origin).

--- a/apps/portagent/src/client/pages/ChatPage.tsx
+++ b/apps/portagent/src/client/pages/ChatPage.tsx
@@ -104,10 +104,10 @@ export function ChatPage() {
         const info = await response.json();
         if (!mounted) return;
 
-        // Use explicit wsUrl from server in dev, or construct from current host in prod
-        const wsUrl =
-          info.wsUrl ||
-          `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}${info.wsPath || "/ws"}`;
+        // Construct WebSocket URL from current host (works for both dev and prod)
+        // In dev: Vite proxy forwards /ws to backend
+        // In prod: Same origin, direct connection
+        const wsUrl = `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}${info.wsPath || "/ws"}`;
 
         // Create AgentX instance in remote mode (WebSocket)
         agentxInstance = await createAgentX({ serverUrl: wsUrl });

--- a/apps/portagent/src/server/index.ts
+++ b/apps/portagent/src/server/index.ts
@@ -156,14 +156,11 @@ async function createApp() {
   // AgentX info endpoint (protected)
   app.use("/agentx/*", authMiddleware);
   app.get("/agentx/info", (c) => {
-    // In development, return full WebSocket URL for Vite proxy
-    const isDev = process.env.NODE_ENV !== "production";
-    const wsUrl = isDev ? `ws://localhost:${PORT}/ws` : undefined;
-
+    // Only return wsPath - frontend uses window.location.host to build full URL
+    // In development, Vite proxy handles WebSocket forwarding
     return c.json({
       version: "0.1.0",
       wsPath: "/ws",
-      wsUrl, // Full URL in dev mode
     });
   });
 


### PR DESCRIPTION
## Summary
- Remove hardcoded `wsUrl` from `/agentx/info` response
- Frontend now always uses `window.location.host` to construct WebSocket URL

## Problem
Bun compiler inlined `process.env.NODE_ENV !== "production"` as `true` during build, causing `wsUrl` to always return `ws://localhost:5200/ws` even in production Docker environments. This broke WebSocket connections when accessing from external hosts.

## Solution
Remove `wsUrl` from server response entirely. This works for both:
- **Development**: Vite proxy forwards `/ws` to backend
- **Production**: Same origin, direct connection

## Test Plan
- [x] Verified `/agentx/info` no longer returns `wsUrl` in Docker environment
- [x] WebSocket connection successful (confirmed by logs showing message sent to Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)